### PR TITLE
Add different text view types and data sources

### DIFF
--- a/pages/raw.py
+++ b/pages/raw.py
@@ -8,14 +8,21 @@ import streamlit.components.v1 as components
 from annotated_text import annotated_text
 
 from retro_pytorch.retrieval import get_tokenizer
-from retro_pytorch.streamlit import (
-    DATA_DIR,
-    DOMAINS,
-    FOLDS,
-    read_corpus,
-    text_with_scrollbar,
-)
+from retro_pytorch.streamlit import DOMAINS, FOLDS, read_corpus, text_with_scrollbar
 from retro_pytorch.utils import parse_meta
+
+DATA_DIR = Path("/datasets01/gptz_corpus_dedup_10_10_1_0.05_exp29/120321/")
+
+
+def read_corpus(*, fold: str, partition: str, domain: str, limit: int = 100, offset: int = 0):
+    docs = []
+    with jsonlines.jsonlines.open(DATA_DIR / fold / partition / f"{domain}.jsonl") as f:
+        for idx, row in enumerate(f):
+            docs.append(row)
+            if idx >= limit:
+                break
+    return docs
+
 
 st.title("Retro Dataset Viewer")
 with st.sidebar:

--- a/retro_pytorch/streamlit.py
+++ b/retro_pytorch/streamlit.py
@@ -1,19 +1,4 @@
-from pathlib import Path
-
-import jsonlines
 import streamlit.components.v1 as components
-
-DATA_DIR = Path("/datasets01/gptz_corpus_dedup_10_10_1_0.05_exp29/120321/")
-
-
-def read_corpus(*, fold: str, partition: str, domain: str, limit: int = 100, offset: int = 0):
-    docs = []
-    with jsonlines.jsonlines.open(DATA_DIR / fold / partition / f"{domain}.jsonl") as f:
-        for idx, row in enumerate(f):
-            docs.append(row)
-            if idx >= limit:
-                break
-    return docs
 
 
 def text_with_scrollbar(text, height="450px"):


### PR DESCRIPTION
Make it possible to view either concatenated text (paragraph mode) or
colorized, tokenized text. Additionally, make it possible to look at
other valid data partitions

ps-id: 1cacb660-dce0-447e-b10f-808187b6821d